### PR TITLE
feat: Mac 위젯 지원 및 위젯 동작 개선

### DIFF
--- a/InspireMe/InspireMeApp.swift
+++ b/InspireMe/InspireMeApp.swift
@@ -2,13 +2,21 @@ import SwiftUI
 
 @main
 struct InspireMeApp: App {
+    @Environment(\.openURL) private var openURL
     @State private var widgetURL: URL?
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .onOpenURL { url in
-                    widgetURL = url
+                    if ProcessInfo.processInfo.isiOSAppOnMac {
+                        openURL(url)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                            UIApplication.shared.perform(#selector(NSXPCConnection.suspend))
+                        }
+                    } else {
+                        widgetURL = url
+                    }
                 }
                 .fullScreenCover(item: $widgetURL) { url in
                     SafariView(url: url)

--- a/InspireMe/Views/MainTabView.swift
+++ b/InspireMe/Views/MainTabView.swift
@@ -12,6 +12,11 @@ struct MainTabView: View {
                 .tabItem {
                     Label("설정", systemImage: "gearshape")
                 }
+
+            WebView()
+                .tabItem {
+                    Label("사이트", systemImage: "globe")
+                }
         }
     }
 }

--- a/InspireMe/Views/WebView.swift
+++ b/InspireMe/Views/WebView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+import WebKit
+
+struct WebView: View {
+    var body: some View {
+        NavigationStack {
+            InspireMeWebView(url: URL(string: "\(InspireMeAPI.baseURL)")!)
+                .navigationTitle("InspireMe")
+                .navigationBarTitleDisplayMode(.inline)
+                .ignoresSafeArea(edges: .bottom)
+        }
+    }
+}
+
+struct InspireMeWebView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+}
+
+#Preview {
+    WebView()
+}

--- a/InspireMeWidget/QuoteEntry.swift
+++ b/InspireMeWidget/QuoteEntry.swift
@@ -15,6 +15,22 @@ struct QuoteEntry: TimelineEntry {
         }
     }
 
+    var quoteURL: URL {
+        if quote.id == "placeholder" {
+            URL(string: InspireMeAPI.baseURL)!
+        } else {
+            URL(string: "\(InspireMeAPI.baseURL)/quotes/\(quote.id)")!
+        }
+    }
+
+    var authorURL: URL {
+        if quote.authorSlug.isEmpty || quote.id == "placeholder" {
+            URL(string: InspireMeAPI.baseURL)!
+        } else {
+            URL(string: "\(InspireMeAPI.baseURL)/authors/\(quote.authorSlug)")!
+        }
+    }
+
     static var placeholder: QuoteEntry {
         QuoteEntry(
             date: .now,

--- a/InspireMeWidget/QuoteOfTheDayWidget.swift
+++ b/InspireMeWidget/QuoteOfTheDayWidget.swift
@@ -11,6 +11,7 @@ struct QuoteOfTheDayWidget: Widget {
                     entry.theme.backgroundGradient
                 }
         }
+        .contentMarginsDisabled()
         .configurationDisplayName("오늘의 명언")
         .description("매일 새로운 명언을 만나보세요")
         .supportedFamilies([

--- a/InspireMeWidget/RandomQuoteWidget.swift
+++ b/InspireMeWidget/RandomQuoteWidget.swift
@@ -11,6 +11,7 @@ struct RandomQuoteWidget: Widget {
                     entry.theme.backgroundGradient
                 }
         }
+        .contentMarginsDisabled()
         .configurationDisplayName("랜덤 명언")
         .description("설정한 주기마다 새로운 명언을 보여줍니다")
         .supportedFamilies([

--- a/InspireMeWidget/RefreshQuoteIntent.swift
+++ b/InspireMeWidget/RefreshQuoteIntent.swift
@@ -6,7 +6,7 @@ struct RefreshQuoteIntent: AppIntent {
     static let description: IntentDescription = "새로운 명언을 불러옵니다"
 
     func perform() async throws -> some IntentResult {
-        WidgetCenter.shared.reloadTimelines(ofKind: "RandomQuoteWidget")
+        WidgetCenter.shared.reloadAllTimelines()
         return .result()
     }
 }

--- a/InspireMeWidget/Views/LargeQuoteView.swift
+++ b/InspireMeWidget/Views/LargeQuoteView.swift
@@ -34,7 +34,7 @@ struct LargeQuoteView: View {
                 .foregroundStyle(entry.theme.accentColor)
 
             // Quote content - tappable
-            Link(destination: URL(string: "\(InspireMeAPI.baseURL)/quotes/\(entry.quote.id)")!) {
+            Link(destination: entry.quoteURL) {
                 Text(entry.quote.content)
                     .font(.system(size: 18, weight: .medium))
                     .foregroundStyle(entry.theme.textColor)
@@ -45,7 +45,7 @@ struct LargeQuoteView: View {
             Spacer()
 
             // Author - tappable
-            Link(destination: URL(string: "\(InspireMeAPI.baseURL)/authors/\(entry.quote.authorSlug)")!) {
+            Link(destination: entry.authorURL) {
                 Text("— \(entry.quote.author)")
                     .font(.subheadline)
                     .foregroundStyle(entry.theme.secondaryTextColor)
@@ -68,7 +68,6 @@ struct LargeQuoteView: View {
         }
         .padding(16)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-        .background(entry.theme.backgroundGradient)
     }
 }
 

--- a/InspireMeWidget/Views/MediumQuoteView.swift
+++ b/InspireMeWidget/Views/MediumQuoteView.swift
@@ -9,7 +9,7 @@ struct MediumQuoteView: View {
         ZStack(alignment: .topTrailing) {
             HStack(spacing: 0) {
                 // Quote area - tappable to quote page
-                Link(destination: URL(string: "\(InspireMeAPI.baseURL)/quotes/\(entry.quote.id)")!) {
+                Link(destination: entry.quoteURL) {
                     VStack(alignment: .leading, spacing: 8) {
                         Text("\u{275D}")
                             .font(.title2)
@@ -33,7 +33,7 @@ struct MediumQuoteView: View {
                 VStack(alignment: .trailing) {
                     Spacer()
 
-                    Link(destination: URL(string: "\(InspireMeAPI.baseURL)/authors/\(entry.quote.authorSlug)")!) {
+                    Link(destination: entry.authorURL) {
                         Text("— \(entry.quote.author)")
                             .font(.caption)
                             .foregroundStyle(entry.theme.secondaryTextColor)
@@ -55,7 +55,6 @@ struct MediumQuoteView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(entry.theme.backgroundGradient)
     }
 }
 

--- a/InspireMeWidget/Views/SmallQuoteView.swift
+++ b/InspireMeWidget/Views/SmallQuoteView.swift
@@ -5,7 +5,7 @@ struct SmallQuoteView: View {
     let entry: QuoteEntry
 
     var body: some View {
-        Link(destination: URL(string: "\(InspireMeAPI.baseURL)/quotes/\(entry.quote.id)")!) {
+        Link(destination: entry.quoteURL) {
             SmallQuoteContent(quote: entry.quote, theme: entry.theme)
         }
     }


### PR DESCRIPTION
## Summary
- Mac에서 위젯 탭 시 기본 브라우저로 열기 (앱은 자동 백그라운드 전환)
- iPhone/iPad에서는 인앱 브라우저(SFSafariViewController) 유지
- placeholder 상태일 때 404 방지 (메인 페이지로 이동)
- 위젯 URL 생성 로직을 QuoteEntry에 집중하여 중복 제거
- RefreshQuoteIntent가 모든 위젯(QuoteOfTheDay + Random) 리로드하도록 수정
- Mac 위젯 렌더링을 위해 contentMarginsDisabled 추가
- 사이트 탭 추가 (앱 내에서 InspireMe 웹사이트 보기)

## Test plan
- [x] iPhone 시뮬레이터에서 위젯 동작 확인
- [x] iPad 시뮬레이터에서 위젯 동작 확인
- [x] Mac (Designed for iPad)에서 위젯 렌더링 확인
- [x] Mac에서 위젯 탭 → 브라우저 열기 확인 (탭 중복 없음)
- [x] placeholder 상태에서 메인 페이지 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)