### PR TITLE
feat: 릴리스 빌드 및 개발 환경 설정 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,18 @@ Shared/             # 앱 ↔ 위젯 공유 코드 (모델, API, 테마)
 project.yml         # XcodeGen 설정
 ```
 
+## 릴리스
+
+```bash
+# 버전 태그 + GitHub Release 생성
+make tag patch   # v1.0.0 → v1.0.1
+make tag minor   # v1.0.0 → v1.1.0
+make tag major   # v1.0.0 → v2.0.0
+
+# Release 아카이브 생성 (로컬)
+make archive
+```
+
 ## 주요 규칙
 
 - 새 소스 파일 추가 후 반드시 `xcodegen generate` 실행

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+.PHONY: help generate build build-sim open archive tag clean
+
+# ========================================
+# 도움말
+# ========================================
+
+help:
+	@echo "InspireMe iOS 개발 명령어"
+	@echo ""
+	@echo "개발:"
+	@echo "  generate    XcodeGen으로 .xcodeproj 생성"
+	@echo "  build       iOS 디바이스용 빌드 (서명 없음)"
+	@echo "  build-sim   iOS 시뮬레이터용 빌드"
+	@echo "  open        Xcode에서 프로젝트 열기"
+	@echo ""
+	@echo "릴리스:"
+	@echo "  archive     Release 아카이브 생성"
+	@echo "  make tag patch|minor|major   버전 태그 + GitHub Release 생성"
+	@echo "  clean       빌드 결과물 삭제"
+
+# ========================================
+# 개발
+# ========================================
+
+generate:
+	@xcodegen generate
+
+build: generate
+	@xcodebuild build \
+		-project InspireMe.xcodeproj \
+		-scheme InspireMe \
+		-sdk iphoneos \
+		CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY=""
+
+build-sim: generate
+	@xcodebuild build \
+		-project InspireMe.xcodeproj \
+		-scheme InspireMe \
+		-destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+
+open: generate
+	@open InspireMe.xcodeproj
+
+# ========================================
+# 릴리스
+# ========================================
+
+VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "1.0.0")
+BUILD_NUMBER := $(shell git rev-list --count HEAD)
+
+archive: generate
+	@echo "Archiving InspireMe v$(VERSION) (build $(BUILD_NUMBER))..."
+	@xcodebuild archive \
+		-project InspireMe.xcodeproj \
+		-scheme InspireMe \
+		-archivePath build/InspireMe.xcarchive \
+		-destination 'generic/platform=iOS' \
+		-allowProvisioningUpdates \
+		MARKETING_VERSION=$(VERSION) \
+		CURRENT_PROJECT_VERSION=$(BUILD_NUMBER)
+
+tag:
+	@./scripts/release.sh $(filter-out $@,$(MAKECMDGOALS))
+
+clean:
+	@rm -rf build/ DerivedData/
+	@echo "Build artifacts cleaned."
+
+# 인자를 타겟으로 인식하지 않도록 처리
+%:
+	@:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,48 @@ inspireme.ios/
         └── 1_inspire_ios_todo.md
 ```
 
-## 개발 환경
+## 설치 방법
+
+### 준비물
+
+- Mac (macOS 14 Sonoma 이상)
+- Xcode 16+ ([Mac App Store](https://apps.apple.com/app/xcode/id497799835)에서 무료 설치)
+- XcodeGen (`brew install xcodegen`)
+- Apple 계정 (무료 계정으로 충분)
+
+### Step 1. 소스 클론 및 프로젝트 생성
+
+```bash
+git clone https://github.com/kenshin579/inspireme.ios.git
+cd inspireme.ios
+xcodegen generate
+open InspireMe.xcodeproj
+```
+
+### Step 2. Xcode에서 서명 설정
+
+두 타겟 모두 본인 계정으로 변경해야 합니다.
+
+1. Xcode 좌측 패널에서 **InspireMe** 프로젝트 클릭
+2. **InspireMe** 타겟 선택 → **Signing & Capabilities** 탭
+   - **Team**: 본인 Apple ID 선택
+   - **Bundle Identifier**: 고유한 값으로 변경 (예: `com.yourname.inspireme`)
+3. **InspireMeWidgetExtension** 타겟도 동일하게 변경
+   - **Team**: 본인 Apple ID 선택
+   - **Bundle Identifier**: 메인 앱 하위로 변경 (예: `com.yourname.inspireme.widget`)
+
+### Step 3. 기기에 빌드 & 실행
+
+| 플랫폼 | 방법 |
+|--------|------|
+| **iPhone / iPad** | USB로 Mac에 연결 → Xcode 상단에서 기기 선택 → **Run** (Cmd+R) |
+| **Mac** (Apple Silicon) | Xcode 상단에서 **My Mac (Designed for iPad)** 선택 → **Run** (Cmd+R) |
+
+처음 실행 시 iPhone/iPad에서 **설정 → 일반 → VPN 및 기기 관리**에서 개발자 앱을 신뢰해야 합니다.
+
+> **참고**: 무료 Apple 계정은 7일마다 앱을 다시 빌드해야 합니다. Apple Developer Program ($99/year) 가입 시 이 제한이 없어집니다.
+
+## 개발 가이드
 
 ### 필수 요구사항
 
@@ -89,20 +130,32 @@ inspireme.ios/
 - XcodeGen (`brew install xcodegen`)
 - Apple Developer 계정 (App Group, WidgetKit Extension 설정에 필요)
 
-### 빌드 & 실행
+### Makefile 명령어
 
 ```bash
-# Xcode 프로젝트 생성 (새 파일 추가 후 필수)
-xcodegen generate
+make help        # 전체 명령어 목록
 
-# Xcode에서 열기
-open InspireMe.xcodeproj
+# 개발
+make generate    # XcodeGen으로 .xcodeproj 생성
+make build-sim   # iOS 시뮬레이터 빌드
+make build       # iOS 디바이스 빌드 (서명 없음)
+make open        # Xcode에서 프로젝트 열기
 
-# CLI 빌드 (iPhone 시뮬레이터)
-xcodebuild build -project InspireMe.xcodeproj -scheme InspireMe \
-  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+# 릴리스
+make archive     # Release 아카이브 생성
+make tag patch   # 패치 버전 태그 + GitHub Release (v1.0.0 → v1.0.1)
+make tag minor   # 마이너 버전 태그 + GitHub Release (v1.0.0 → v1.1.0)
+make tag major   # 메이저 버전 태그 + GitHub Release (v1.0.0 → v2.0.0)
+make clean       # 빌드 결과물 삭제
+```
 
-# CLI 빌드 (Mac)
+### CLI 빌드
+
+```bash
+# iPhone 시뮬레이터
+make build-sim
+
+# Mac (Designed for iPad)
 xcodebuild build -project InspireMe.xcodeproj -scheme InspireMe \
   -destination 'platform=macOS,variant=Designed for iPad' -allowProvisioningUpdates
 ```

--- a/project.yml
+++ b/project.yml
@@ -12,6 +12,18 @@ settings:
     SWIFT_STRICT_CONCURRENCY: complete
     MARKETING_VERSION: "1.0.0"
     CURRENT_PROJECT_VERSION: 1
+    DEVELOPMENT_TEAM: 3PLL9LS3T3
+
+schemes:
+  InspireMe:
+    build:
+      targets:
+        InspireMe: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+      revealArchiveInOrganizer: true
 
 targets:
   InspireMe:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+VERSION_TYPE=${1:-patch}
+
+# 최신 태그 가져오기
+git fetch --tags
+LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+CURRENT_VERSION=${LATEST_TAG#v}
+
+# 버전 파싱
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+# 버전 범프
+case $VERSION_TYPE in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+  *) echo "Usage: $0 [patch|minor|major]"; exit 1 ;;
+esac
+
+NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+
+echo "Current version: $LATEST_TAG"
+echo "New version: $NEW_VERSION"
+
+# Git 태그 생성 및 푸시
+git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
+git push origin "$NEW_VERSION"
+
+# GitHub 릴리스 생성
+gh release create "$NEW_VERSION" \
+  --title "$NEW_VERSION" \
+  --generate-notes
+
+echo "Released: $NEW_VERSION"


### PR DESCRIPTION
## Summary
- Makefile 추가 (`generate`, `build`, `build-sim`, `archive`, `tag`, `clean` 타겟)
- `scripts/release.sh` 추가 (버전 태그 + GitHub Release 자동 생성)
- `project.yml`에 scheme 정의 및 `DEVELOPMENT_TEAM` 설정 (xcodegen 재생성 시 scheme 유지)
- README.md에 설치 가이드 (Step 1~3) 및 Makefile 명령어 문서화
- CLAUDE.md에 릴리스 명령어 섹션 추가

## Test plan
- [x] `make help` — 명령어 목록 출력 확인
- [x] `make build-sim` — 시뮬레이터 빌드 성공
- [x] `make tag patch` — v0.1.1 태그 + GitHub Release 생성 확인
- [x] iPhone 실기기 빌드 및 설치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)